### PR TITLE
Interface Support: Step 1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,7 +112,7 @@ configure(coreModule) {
     task createDb(dependsOn: assembleDbScripts, description: 'Creates local database', type: CubaDbCreation) {
         dbms = 'hsql'
         host = 'localhost:9010'
-        dbName = 'ceuesr'
+        dbName = 'ceuesr-test'
         dbUser = 'sa'
         dbPassword = ''
     }
@@ -120,7 +120,7 @@ configure(coreModule) {
     task updateDb(dependsOn: assembleDbScripts, description: 'Updates local database', type: CubaDbUpdate) {
         dbms = 'hsql'
         host = 'localhost:9010'
-        dbName = 'ceuesr'
+        dbName = 'ceuesr-test'
         dbUser = 'sa'
         dbPassword = ''
     }

--- a/modules/core/db/init/hsql/10.create-db.sql
+++ b/modules/core/db/init/hsql/10.create-db.sql
@@ -43,6 +43,7 @@ create table CEUESR_DOCUMENT (
     --
     NAME varchar(255),
     REFERS_TO varchar(255),
+    DOCUMENTS varchar(255),
     FILE_ID varchar(36),
     --
     primary key (ID)

--- a/modules/core/web/META-INF/context.xml
+++ b/modules/core/web/META-INF/context.xml
@@ -8,7 +8,7 @@
       maxIdle="2"
       maxWaitMillis="5000"
       driverClassName="org.hsqldb.jdbc.JDBCDriver"
-      url="jdbc:hsqldb:hsql://localhost:9010/ceuesr"
+      url="jdbc:hsqldb:hsql://localhost:9010/ceuesr-test"
       username="sa"
       password=""/>
 

--- a/modules/global/src/de/diedavids/cuba/ceuesr/entity/Customer.java
+++ b/modules/global/src/de/diedavids/cuba/ceuesr/entity/Customer.java
@@ -6,11 +6,13 @@ import com.haulmont.cuba.core.entity.StandardEntity;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Table;
+import java.util.UUID;
 
 @NamePattern("%s|name")
 @Table(name = "CEUESR_CUSTOMER")
 @Entity(name = "ceuesr_Customer")
 public class Customer extends StandardEntity {
+
     @Column(name = "NAME")
     protected String name;
 

--- a/modules/global/src/de/diedavids/cuba/ceuesr/entity/Document.java
+++ b/modules/global/src/de/diedavids/cuba/ceuesr/entity/Document.java
@@ -18,9 +18,22 @@ public class Document extends StandardEntity {
     @Convert(converter = EntitySoftReferenceConverter.class)
     protected com.haulmont.cuba.core.entity.Entity refersTo;
 
+    @MetaProperty(datatype = "Documentable")
+    @Column(name = "DOCUMENTS")
+    @Convert(converter = DocumentableConverter.class)
+    protected Documentable documents;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "FILE_ID")
     protected FileDescriptor file;
+
+    public Documentable getDocuments() {
+        return documents;
+    }
+
+    public void setDocuments(Documentable documents) {
+        this.documents = documents;
+    }
 
     public FileDescriptor getFile() {
         return file;
@@ -37,6 +50,7 @@ public class Document extends StandardEntity {
     public void setRefersTo(com.haulmont.cuba.core.entity.Entity refersTo) {
         this.refersTo = refersTo;
     }
+
 
     public String getName() {
         return name;

--- a/modules/global/src/de/diedavids/cuba/ceuesr/entity/Documentable.java
+++ b/modules/global/src/de/diedavids/cuba/ceuesr/entity/Documentable.java
@@ -1,0 +1,6 @@
+package de.diedavids.cuba.ceuesr.entity;
+
+import com.haulmont.cuba.core.entity.Entity;
+
+public interface Documentable<T> extends Entity<T> {
+}

--- a/modules/global/src/de/diedavids/cuba/ceuesr/entity/DocumentableConverter.java
+++ b/modules/global/src/de/diedavids/cuba/ceuesr/entity/DocumentableConverter.java
@@ -1,0 +1,70 @@
+package de.diedavids.cuba.ceuesr.entity;
+
+import com.google.common.base.Strings;
+import com.haulmont.chile.core.model.MetaClass;
+import com.haulmont.cuba.core.entity.Entity;
+import com.haulmont.cuba.core.global.*;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+@Converter(autoApply = true)
+public class DocumentableConverter implements AttributeConverter<Documentable, String> {
+
+    @Override
+    public String convertToDatabaseColumn(Documentable softReference) {
+
+        if (softReference == null)
+            return "";
+
+        EntityLoadInfoBuilder builder = getEntityLoadInfoBuilder();
+
+        EntityLoadInfo entityLoadInfo = builder.create(softReference);
+
+
+        return entityLoadInfo.toString();
+    }
+
+    @Override
+    public Documentable convertToEntityAttribute(String value) {
+
+
+        if (Strings.isNullOrEmpty(value))
+            return null;
+
+        EntityLoadInfoBuilder builder = getEntityLoadInfoBuilder();
+        EntityLoadInfo entityLoadInfo = builder.parse(value);
+
+        Documentable entity = null;
+
+        if (entityLoadInfo != null) {
+            entity = loadEntity(entityLoadInfo);
+        }
+
+        return entity;
+    }
+
+    private Documentable loadEntity(EntityLoadInfo entityLoadInfo) {
+        DataManager dataManager = getDataManager();
+        return (Documentable) dataManager.load(getLoadContextForForEntityLoadInfo(entityLoadInfo.getMetaClass(), entityLoadInfo.getId()));
+    }
+
+    private DataManager getDataManager() {
+        return AppBeans.get(DataManager.NAME);
+    }
+
+
+    protected LoadContext getLoadContextForForEntityLoadInfo(MetaClass metaClass, Object entityId) {
+        LoadContext loadContext = LoadContext.create(metaClass.getJavaClass());
+        loadContext
+                .setId(entityId);
+        return loadContext;
+    }
+
+
+
+    private EntityLoadInfoBuilder getEntityLoadInfoBuilder() {
+        return AppBeans.get(EntityLoadInfoBuilder.NAME);
+    }
+
+}

--- a/modules/global/src/de/diedavids/cuba/ceuesr/entity/DocumentableConverter.java
+++ b/modules/global/src/de/diedavids/cuba/ceuesr/entity/DocumentableConverter.java
@@ -1,70 +1,8 @@
 package de.diedavids.cuba.ceuesr.entity;
 
-import com.google.common.base.Strings;
-import com.haulmont.chile.core.model.MetaClass;
-import com.haulmont.cuba.core.entity.Entity;
-import com.haulmont.cuba.core.global.*;
-
-import javax.persistence.AttributeConverter;
 import javax.persistence.Converter;
 
 @Converter(autoApply = true)
-public class DocumentableConverter implements AttributeConverter<Documentable, String> {
-
-    @Override
-    public String convertToDatabaseColumn(Documentable softReference) {
-
-        if (softReference == null)
-            return "";
-
-        EntityLoadInfoBuilder builder = getEntityLoadInfoBuilder();
-
-        EntityLoadInfo entityLoadInfo = builder.create(softReference);
-
-
-        return entityLoadInfo.toString();
-    }
-
-    @Override
-    public Documentable convertToEntityAttribute(String value) {
-
-
-        if (Strings.isNullOrEmpty(value))
-            return null;
-
-        EntityLoadInfoBuilder builder = getEntityLoadInfoBuilder();
-        EntityLoadInfo entityLoadInfo = builder.parse(value);
-
-        Documentable entity = null;
-
-        if (entityLoadInfo != null) {
-            entity = loadEntity(entityLoadInfo);
-        }
-
-        return entity;
-    }
-
-    private Documentable loadEntity(EntityLoadInfo entityLoadInfo) {
-        DataManager dataManager = getDataManager();
-        return (Documentable) dataManager.load(getLoadContextForForEntityLoadInfo(entityLoadInfo.getMetaClass(), entityLoadInfo.getId()));
-    }
-
-    private DataManager getDataManager() {
-        return AppBeans.get(DataManager.NAME);
-    }
-
-
-    protected LoadContext getLoadContextForForEntityLoadInfo(MetaClass metaClass, Object entityId) {
-        LoadContext loadContext = LoadContext.create(metaClass.getJavaClass());
-        loadContext
-                .setId(entityId);
-        return loadContext;
-    }
-
-
-
-    private EntityLoadInfoBuilder getEntityLoadInfoBuilder() {
-        return AppBeans.get(EntityLoadInfoBuilder.NAME);
-    }
+public class DocumentableConverter extends EntitySoftReferenceInterfaceConverter<Documentable> {
 
 }

--- a/modules/global/src/de/diedavids/cuba/ceuesr/entity/DocumentableDatatype.java
+++ b/modules/global/src/de/diedavids/cuba/ceuesr/entity/DocumentableDatatype.java
@@ -1,85 +1,10 @@
 package de.diedavids.cuba.ceuesr.entity;
 
-import com.google.common.base.Strings;
-import com.haulmont.chile.core.datatypes.Datatype;
-import com.haulmont.chile.core.model.MetaClass;
-import com.haulmont.cuba.core.entity.Entity;
-import com.haulmont.cuba.core.global.*;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.text.ParseException;
-import java.util.Locale;
-
-public class DocumentableDatatype implements Datatype<Documentable> {
+public class DocumentableDatatype extends EntitySoftReferenceInterfaceDatatype<Documentable> {
 
     @Override
     public Class getJavaClass() {
         return Documentable.class;
-    }
-
-    @Nonnull
-    @Override
-    public String format(@Nullable Object value) {
-
-        if (value == null) {
-            return "";
-        }
-
-        EntityLoadInfoBuilder builder = getEntityLoadInfoBuilder();
-        EntityLoadInfo entityLoadInfo = builder.create((Entity) value);
-        return entityLoadInfo.toString();
-
-    }
-
-    private EntityLoadInfoBuilder getEntityLoadInfoBuilder() {
-        return AppBeans.get(EntityLoadInfoBuilder.NAME);
-    }
-
-    @Nonnull
-    @Override
-    public String format(@Nullable Object value, Locale locale) {
-        return format(value);
-    }
-
-    @Nullable
-    @Override
-    public Documentable parse(@Nullable String value) throws ParseException {
-
-
-        if (Strings.isNullOrEmpty(value))
-            return null;
-
-
-        EntityLoadInfoBuilder builder = getEntityLoadInfoBuilder();
-        EntityLoadInfo entityLoadInfo = builder.parse(value);
-
-        Documentable entity = loadEntity(entityLoadInfo);
-
-        return entity;
-    }
-
-    private Documentable loadEntity(EntityLoadInfo entityLoadInfo) {
-        DataManager dataManager = getDataManager();
-        return (Documentable) dataManager.load(getLoadContextForForEntityLoadInfo(entityLoadInfo.getMetaClass(), entityLoadInfo.getId()));
-    }
-
-    private DataManager getDataManager() {
-        return AppBeans.get(DataManager.NAME);
-    }
-
-
-    protected LoadContext getLoadContextForForEntityLoadInfo(MetaClass metaClass, Object entityId) {
-        LoadContext loadContext = LoadContext.create(metaClass.getJavaClass());
-        loadContext
-                .setId(entityId);
-        return loadContext;
-    }
-
-    @Nullable
-    @Override
-    public Documentable parse(@Nullable String value, Locale locale) throws ParseException {
-        return parse(value);
     }
 
 }

--- a/modules/global/src/de/diedavids/cuba/ceuesr/entity/DocumentableDatatype.java
+++ b/modules/global/src/de/diedavids/cuba/ceuesr/entity/DocumentableDatatype.java
@@ -1,0 +1,85 @@
+package de.diedavids.cuba.ceuesr.entity;
+
+import com.google.common.base.Strings;
+import com.haulmont.chile.core.datatypes.Datatype;
+import com.haulmont.chile.core.model.MetaClass;
+import com.haulmont.cuba.core.entity.Entity;
+import com.haulmont.cuba.core.global.*;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.text.ParseException;
+import java.util.Locale;
+
+public class DocumentableDatatype implements Datatype<Documentable> {
+
+    @Override
+    public Class getJavaClass() {
+        return Documentable.class;
+    }
+
+    @Nonnull
+    @Override
+    public String format(@Nullable Object value) {
+
+        if (value == null) {
+            return "";
+        }
+
+        EntityLoadInfoBuilder builder = getEntityLoadInfoBuilder();
+        EntityLoadInfo entityLoadInfo = builder.create((Entity) value);
+        return entityLoadInfo.toString();
+
+    }
+
+    private EntityLoadInfoBuilder getEntityLoadInfoBuilder() {
+        return AppBeans.get(EntityLoadInfoBuilder.NAME);
+    }
+
+    @Nonnull
+    @Override
+    public String format(@Nullable Object value, Locale locale) {
+        return format(value);
+    }
+
+    @Nullable
+    @Override
+    public Documentable parse(@Nullable String value) throws ParseException {
+
+
+        if (Strings.isNullOrEmpty(value))
+            return null;
+
+
+        EntityLoadInfoBuilder builder = getEntityLoadInfoBuilder();
+        EntityLoadInfo entityLoadInfo = builder.parse(value);
+
+        Documentable entity = loadEntity(entityLoadInfo);
+
+        return entity;
+    }
+
+    private Documentable loadEntity(EntityLoadInfo entityLoadInfo) {
+        DataManager dataManager = getDataManager();
+        return (Documentable) dataManager.load(getLoadContextForForEntityLoadInfo(entityLoadInfo.getMetaClass(), entityLoadInfo.getId()));
+    }
+
+    private DataManager getDataManager() {
+        return AppBeans.get(DataManager.NAME);
+    }
+
+
+    protected LoadContext getLoadContextForForEntityLoadInfo(MetaClass metaClass, Object entityId) {
+        LoadContext loadContext = LoadContext.create(metaClass.getJavaClass());
+        loadContext
+                .setId(entityId);
+        return loadContext;
+    }
+
+    @Nullable
+    @Override
+    public Documentable parse(@Nullable String value, Locale locale) throws ParseException {
+        return parse(value);
+    }
+
+}

--- a/modules/global/src/de/diedavids/cuba/ceuesr/entity/EntitySoftReferenceInterfaceConverter.java
+++ b/modules/global/src/de/diedavids/cuba/ceuesr/entity/EntitySoftReferenceInterfaceConverter.java
@@ -1,0 +1,68 @@
+package de.diedavids.cuba.ceuesr.entity;
+
+import com.google.common.base.Strings;
+import com.haulmont.chile.core.model.MetaClass;
+import com.haulmont.cuba.core.entity.Entity;
+import com.haulmont.cuba.core.global.*;
+
+import javax.persistence.AttributeConverter;
+
+public abstract class EntitySoftReferenceInterfaceConverter<T extends Entity> implements AttributeConverter<T, String> {
+
+    @Override
+    public String convertToDatabaseColumn(T softReference) {
+
+        if (softReference == null)
+            return "";
+
+        EntityLoadInfoBuilder builder = getEntityLoadInfoBuilder();
+
+        EntityLoadInfo entityLoadInfo = builder.create(softReference);
+
+
+        return entityLoadInfo.toString();
+    }
+
+    @Override
+    public T convertToEntityAttribute(String value) {
+
+
+        if (Strings.isNullOrEmpty(value))
+            return null;
+
+        EntityLoadInfoBuilder builder = getEntityLoadInfoBuilder();
+        EntityLoadInfo entityLoadInfo = builder.parse(value);
+
+        T entity = null;
+
+        if (entityLoadInfo != null) {
+            entity = loadEntity(entityLoadInfo);
+        }
+
+        return entity;
+    }
+
+    private T loadEntity(EntityLoadInfo entityLoadInfo) {
+        DataManager dataManager = getDataManager();
+        return (T) dataManager.load(getLoadContextForForEntityLoadInfo(entityLoadInfo.getMetaClass(), entityLoadInfo.getId()));
+    }
+
+    private DataManager getDataManager() {
+        return AppBeans.get(DataManager.NAME);
+    }
+
+
+    protected LoadContext getLoadContextForForEntityLoadInfo(MetaClass metaClass, Object entityId) {
+        LoadContext loadContext = LoadContext.create(metaClass.getJavaClass());
+        loadContext
+                .setId(entityId);
+        return loadContext;
+    }
+
+
+
+    private EntityLoadInfoBuilder getEntityLoadInfoBuilder() {
+        return AppBeans.get(EntityLoadInfoBuilder.NAME);
+    }
+
+}

--- a/modules/global/src/de/diedavids/cuba/ceuesr/entity/EntitySoftReferenceInterfaceDatatype.java
+++ b/modules/global/src/de/diedavids/cuba/ceuesr/entity/EntitySoftReferenceInterfaceDatatype.java
@@ -1,0 +1,81 @@
+package de.diedavids.cuba.ceuesr.entity;
+
+import com.google.common.base.Strings;
+import com.haulmont.chile.core.datatypes.Datatype;
+import com.haulmont.chile.core.model.MetaClass;
+import com.haulmont.cuba.core.entity.Entity;
+import com.haulmont.cuba.core.global.*;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.text.ParseException;
+import java.util.Locale;
+
+public abstract class EntitySoftReferenceInterfaceDatatype<T extends Entity> implements Datatype<T> {
+
+
+    @Nonnull
+    @Override
+    public String format(@Nullable Object value) {
+
+        if (value == null) {
+            return "";
+        }
+
+        EntityLoadInfoBuilder builder = getEntityLoadInfoBuilder();
+        EntityLoadInfo entityLoadInfo = builder.create((Entity) value);
+        return entityLoadInfo.toString();
+
+    }
+
+    private EntityLoadInfoBuilder getEntityLoadInfoBuilder() {
+        return AppBeans.get(EntityLoadInfoBuilder.NAME);
+    }
+
+    @Nonnull
+    @Override
+    public String format(@Nullable Object value, Locale locale) {
+        return format(value);
+    }
+
+    @Nullable
+    @Override
+    public T parse(@Nullable String value) throws ParseException {
+
+
+        if (Strings.isNullOrEmpty(value))
+            return null;
+
+
+        EntityLoadInfoBuilder builder = getEntityLoadInfoBuilder();
+        EntityLoadInfo entityLoadInfo = builder.parse(value);
+
+        T entity = loadEntity(entityLoadInfo);
+
+        return entity;
+    }
+
+    private T loadEntity(EntityLoadInfo entityLoadInfo) {
+        DataManager dataManager = getDataManager();
+        return (T) dataManager.load(getLoadContextForForEntityLoadInfo(entityLoadInfo.getMetaClass(), entityLoadInfo.getId()));
+    }
+
+    private DataManager getDataManager() {
+        return AppBeans.get(DataManager.NAME);
+    }
+
+
+    protected LoadContext getLoadContextForForEntityLoadInfo(MetaClass metaClass, Object entityId) {
+        LoadContext loadContext = LoadContext.create(metaClass.getJavaClass());
+        loadContext
+                .setId(entityId);
+        return loadContext;
+    }
+
+    @Nullable
+    @Override
+    public T parse(@Nullable String value, Locale locale) throws ParseException {
+        return parse(value);
+    }
+
+}

--- a/modules/global/src/de/diedavids/cuba/ceuesr/entity/Order.java
+++ b/modules/global/src/de/diedavids/cuba/ceuesr/entity/Order.java
@@ -4,12 +4,14 @@ import com.haulmont.chile.core.annotations.NamePattern;
 import com.haulmont.cuba.core.entity.StandardEntity;
 
 import javax.persistence.*;
+import javax.swing.text.Document;
 import java.util.Date;
+import java.util.UUID;
 
 @NamePattern("%s|orderDate")
 @Table(name = "CEUESR_ORDER")
 @Entity(name = "ceuesr_Order")
-public class Order extends StandardEntity {
+public class Order extends StandardEntity{
     @Temporal(TemporalType.DATE)
     @Column(name = "ORDER_DATE")
     protected Date orderDate;

--- a/modules/global/src/de/diedavids/cuba/ceuesr/metadata.xml
+++ b/modules/global/src/de/diedavids/cuba/ceuesr/metadata.xml
@@ -1,6 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <metadata xmlns="http://schemas.haulmont.com/cuba/metadata.xsd">
 
+
+    <datatypes>
+        <datatype
+                id="Documentable"
+                class="de.diedavids.cuba.ceuesr.entity.DocumentableDatatype"
+                javaType="de.diedavids.cuba.ceuesr.entity.Documentable"
+                sqlType="varchar(255)"
+        />
+    </datatypes>
     <metadata-model root-package="de.diedavids.cuba.ceuesr" namespace="ceuesr"/>
 
 </metadata>

--- a/modules/global/src/de/diedavids/cuba/ceuesr/persistence.xml
+++ b/modules/global/src/de/diedavids/cuba/ceuesr/persistence.xml
@@ -5,5 +5,6 @@
         <class>de.diedavids.cuba.ceuesr.entity.Customer</class>
         <class>de.diedavids.cuba.ceuesr.entity.Order</class>
         <class>de.diedavids.cuba.ceuesr.entity.Document</class>
+        <class>de.diedavids.cuba.ceuesr.entity.DocumentableConverter</class>
     </persistence-unit>
 </persistence>

--- a/modules/web/src/de/diedavids/cuba/ceuesr/web/document/DocumentEdit.java
+++ b/modules/web/src/de/diedavids/cuba/ceuesr/web/document/DocumentEdit.java
@@ -2,7 +2,8 @@ package de.diedavids.cuba.ceuesr.web.document;
 
 import com.haulmont.cuba.core.entity.Entity;
 import com.haulmont.cuba.gui.ScreenBuilders;
-import com.haulmont.cuba.gui.components.*;
+import com.haulmont.cuba.gui.components.Action;
+import com.haulmont.cuba.gui.components.Form;
 import com.haulmont.cuba.gui.model.InstanceContainer;
 import com.haulmont.cuba.gui.screen.*;
 import de.diedavids.cuba.ceuesr.entity.Customer;


### PR DESCRIPTION
### Documentable Interface

The idea is to also support interfaces instead of generic `Entity` references.

The example would be to have a dedicated `Documentable` interface that is referenced in the `Document` entity like this:

```
    @MetaProperty(datatype = "Documentable")
    @Column(name = "DOCUMENTS")
    @Convert(converter = DocumentableConverter.class)
    protected Documentable documents;
```

The old example `refersTo` uses the generic `Entity` attribute:

```
    @MetaProperty(datatype = "EntitySoftReference")
    @Column(name = "REFERS_TO")
    @Convert(converter = EntitySoftReferenceConverter.class)
    protected com.haulmont.cuba.core.entity.Entity refersTo;
```

The benefit of the idea is, that the application gets better strong typing.

### Step 1
The first step works. It contains the following abstractions:

* `EntitySoftReferenceInterfaceConverter`
* `EntitySoftReferenceInterfaceDatatype`
* `DocumentableConverter`
* `DocumentableDatatype`
* registrations in `persistence.xml` and `metadata.xml`

The second step (different branch based on this one, does not work anymore).
