### PR TITLE
Interface support lookup value source

### DIFF
--- a/modules/web/src/de/diedavids/cuba/ceuesr/web/EntitySoftReferenceLookupAction.java
+++ b/modules/web/src/de/diedavids/cuba/ceuesr/web/EntitySoftReferenceLookupAction.java
@@ -83,14 +83,32 @@ public class EntitySoftReferenceLookupAction extends LookupAction {
 
                             MetaClass metaClass = metadata.getClass(entityClassValue);
 
-                            /*
-                            the meta class is fetched from dialog and passed into the picker field. Afterwards the super method is called,
-                            which in case the meta class is set will not treat it as a regular lookup with valueSource
-                             */
-                            pickerField.setMetaClass(metaClass);
+                            screenBuilders.lookup(metaClass.getJavaClass(), pickerField.getFrame().getFrameOwner())
+                                    .withOpenMode(OpenMode.DIALOG)
+                                    .withSelectHandler(selectedEntities -> {
 
-                            super.actionPerform(component);
+                                        /*
+                                        within this call there is a java type check in the method:
 
+                                        WebPickerField#checkValueType which causes problems with this code:
+                                        --------
+                                        MetaProperty metaProperty = ((EntityValueSource) valueSource).getMetaPropertyPath().getMetaProperty();
+                                        return metaProperty.getRange().asClass();
+                                        --------
+
+                                        the asClass() method throws an exception:
+
+                                        java.lang.IllegalStateException: Range is datatype
+                                            at com.haulmont.chile.core.model.impl.DatatypeRange.asClass(DatatypeRange.java:35)
+                                            at com.haulmont.cuba.web.gui.components.WebPickerField.getMetaClass(WebPickerField.java:173)
+                                            at com.haulmont.cuba.web.gui.components.WebPickerField.checkValueType(WebPickerField.java:119)
+                                            at com.haulmont.cuba.web.gui.components.WebPickerField.setValue(WebPickerField.java:97)
+                                            at com.haulmont.cuba.web.gui.components.WebPickerField.setValue(WebPickerField.java:59)
+                                         */
+
+                                        pickerField.setValue(selectedEntities.iterator().next());
+                                    })
+                                    .show();
                         }
                     })
                     .show();

--- a/modules/web/src/de/diedavids/cuba/ceuesr/web/comment/CommentEdit.java
+++ b/modules/web/src/de/diedavids/cuba/ceuesr/web/comment/CommentEdit.java
@@ -1,56 +1,12 @@
 package de.diedavids.cuba.ceuesr.web.comment;
 
-import com.haulmont.cuba.core.global.Messages;
-import com.haulmont.cuba.core.global.Metadata;
-import com.haulmont.cuba.gui.Notifications;
-import com.haulmont.cuba.gui.components.*;
-import com.haulmont.cuba.gui.components.data.value.ContainerValueSource;
-import com.haulmont.cuba.gui.model.InstanceContainer;
 import com.haulmont.cuba.gui.screen.*;
 import de.diedavids.cuba.ceuesr.entity.Comment;
-import de.diedavids.cuba.ceuesr.entity.Commentable;
-import de.diedavids.cuba.ceuesr.web.EntitySoftReferenceLookupAction;
-import de.diedavids.cuba.entitysoftreference.web.SoftReferenceFormFieldGenerator;
-
-import javax.inject.Inject;
-import javax.inject.Named;
 
 @UiController("ceuesr_Comment.edit")
 @UiDescriptor("comment-edit.xml")
 @EditedEntityContainer("commentDc")
 @LoadDataBeforeShow
 public class CommentEdit extends StandardEditor<Comment> {
-
-
-//    @Inject
-//    protected InstanceContainer<Comment> commentDc;
-//
-//    @Inject
-//    protected PickerField<Commentable> commentsField;
-//
-//
-//    @Subscribe
-//    protected void onInit(InitEvent event) {
-//
-//        commentsField.addValueChangeListener(valueChangeEvent -> {
-//            Commentable value = valueChangeEvent.getValue();
-//            commentDc.getItem().setComments(value);
-//        });
-//    }
-//
-//    @Subscribe
-//    protected void onAfterShow(AfterShowEvent event) {
-//        Commentable comments = commentDc.getItem().getComments();
-//
-//        if (comments != null) {
-//            /*
-//            set meta class of the field to the target meta class
-//             */
-//            commentsField.setMetaClass(comments.getMetaClass());
-//            commentsField.setValue(comments);
-//        }
-//
-//    }
-    
 
 }

--- a/modules/web/src/de/diedavids/cuba/ceuesr/web/comment/CommentEdit.java
+++ b/modules/web/src/de/diedavids/cuba/ceuesr/web/comment/CommentEdit.java
@@ -22,35 +22,35 @@ import javax.inject.Named;
 public class CommentEdit extends StandardEditor<Comment> {
 
 
-    @Inject
-    protected InstanceContainer<Comment> commentDc;
-
-    @Inject
-    protected PickerField<Commentable> commentsField;
-
-
-    @Subscribe
-    protected void onInit(InitEvent event) {
-
-        commentsField.addValueChangeListener(valueChangeEvent -> {
-            Commentable value = valueChangeEvent.getValue();
-            commentDc.getItem().setComments(value);
-        });
-    }
-
-    @Subscribe
-    protected void onAfterShow(AfterShowEvent event) {
-        Commentable comments = commentDc.getItem().getComments();
-
-        if (comments != null) {
-            /*
-            set meta class of the field to the target meta class
-             */
-            commentsField.setMetaClass(comments.getMetaClass());
-            commentsField.setValue(comments);
-        }
-
-    }
+//    @Inject
+//    protected InstanceContainer<Comment> commentDc;
+//
+//    @Inject
+//    protected PickerField<Commentable> commentsField;
+//
+//
+//    @Subscribe
+//    protected void onInit(InitEvent event) {
+//
+//        commentsField.addValueChangeListener(valueChangeEvent -> {
+//            Commentable value = valueChangeEvent.getValue();
+//            commentDc.getItem().setComments(value);
+//        });
+//    }
+//
+//    @Subscribe
+//    protected void onAfterShow(AfterShowEvent event) {
+//        Commentable comments = commentDc.getItem().getComments();
+//
+//        if (comments != null) {
+//            /*
+//            set meta class of the field to the target meta class
+//             */
+//            commentsField.setMetaClass(comments.getMetaClass());
+//            commentsField.setValue(comments);
+//        }
+//
+//    }
     
 
 }

--- a/modules/web/src/de/diedavids/cuba/ceuesr/web/comment/comment-edit.xml
+++ b/modules/web/src/de/diedavids/cuba/ceuesr/web/comment/comment-edit.xml
@@ -20,11 +20,10 @@
 
                 <!--
 
-                the picker field does not use automatic binding in this case (by setting the property value),
-                instead the binding is done manually through the controller.
+                value source is used here
                 -->
                 <pickerField id="commentsField"
-                             caption="msg://comments"
+                             property="comments"
                 >
                     <actions>
                         <action id="lookup" type="entitySoftReferencePicker_lookup"/>


### PR DESCRIPTION
This change uses valueSource (default) to bind the values. It creates an exception when binding the value:

```
java.lang.IllegalStateException: Range is datatype
   at com.haulmont.chile.core.model.impl.DatatypeRange.asClass(DatatypeRange.java:35)
   at com.haulmont.cuba.web.gui.components.WebPickerField.getMetaClass(WebPickerField.java:173)
   at com.haulmont.cuba.web.gui.components.WebPickerField.checkValueType(WebPickerField.java:119)
   at com.haulmont.cuba.web.gui.components.WebPickerField.setValue(WebPickerField.java:97)
   at com.haulmont.cuba.web.gui.components.WebPickerField.setValue(WebPickerField.java:59)
```

![2019-10-08 14 10 49](https://user-images.githubusercontent.com/817400/66394551-bd9d0180-e9d5-11e9-8f7a-719c669822ce.gif)
